### PR TITLE
chore: harden release and CI workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   detect:
     name: Detect OpenAPI change
@@ -15,7 +18,7 @@ jobs:
       changed: ${{ steps.diff.outputs.changed }}
       spec_url: ${{ steps.spec.outputs.spec_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Ensure jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -163,7 +166,7 @@ jobs:
 
       - name: Upload normalized specs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: normalized-specs
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -17,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -29,7 +32,7 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
@@ -41,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Reuse the existing test workflow
   test:
@@ -63,13 +66,13 @@ jobs:
     steps:
       - name: Create GitHub App token (release-bot)
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Fetch full history for version tagging
           fetch-depth: 0
@@ -94,7 +97,7 @@ jobs:
       # Generator always fetches remote; no local spec path needed
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: "pip"
@@ -199,38 +202,6 @@ jobs:
           fi
           git add CHANGELOG.md
 
-      - name: Build package
-        run: |
-          echo "🔄 Building package..."
-          # Clean any existing build artifacts
-          rm -rf dist/
-          hatch build
-          echo "✅ Package built successfully"
-          ls -la dist/
-
-      - name: Upload to PyPI
-        if: ${{ !inputs.dry_run }}
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          echo "🔄 Uploading to PyPI..."
-          hatch publish --repo https://upload.pypi.org/legacy/
-          echo "✅ Package uploaded to PyPI"
-
-      - name: Commit version bump
-        if: ${{ !inputs.dry_run }}
-        run: |
-          git add -A
-          git commit -m "Bump version to ${{ steps.new_version.outputs.version }}"
-          git push origin HEAD
-
-      - name: Create and push tag
-        if: ${{ !inputs.dry_run }}
-        run: |
-          git tag -a "v${{ steps.new_version.outputs.version }}" -m "Release v${{ steps.new_version.outputs.version }}"
-          git push origin "v${{ steps.new_version.outputs.version }}"
-
       - name: Build release notes
         if: ${{ !inputs.dry_run }}
         env:
@@ -263,9 +234,41 @@ jobs:
           echo "Generated release notes:"
           cat release-notes.md
 
+      - name: Build package
+        run: |
+          echo "🔄 Building package..."
+          # Clean any existing build artifacts
+          rm -rf dist/
+          hatch build
+          echo "✅ Package built successfully"
+          ls -la dist/
+
+      - name: Upload to PyPI
+        if: ${{ !inputs.dry_run }}
+        env:
+          HATCH_INDEX_USER: __token__
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          echo "🔄 Uploading to PyPI..."
+          hatch publish --repo https://upload.pypi.org/legacy/
+          echo "✅ Package uploaded to PyPI"
+
+      - name: Commit version bump
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git add -A
+          git commit -m "Bump version to ${{ steps.new_version.outputs.version }}"
+          git push origin HEAD
+
+      - name: Create and push tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git tag -a "v${{ steps.new_version.outputs.version }}" -m "Release v${{ steps.new_version.outputs.version }}"
+          git push origin "v${{ steps.new_version.outputs.version }}"
+
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           tag_name: "v${{ steps.new_version.outputs.version }}"
@@ -275,7 +278,7 @@ jobs:
 
       - name: Upload build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist-${{ steps.new_version.outputs.version }}
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]
@@ -25,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -71,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: "pip"


### PR DESCRIPTION
## Summary
- pin GitHub Actions to exact SHAs and opt workflows into the Node 24 JavaScript action runtime
- fix release ordering so GitHub release notes are generated before the metadata bump commit
- keep docs and test workflows on the current Python 3.13 setup with pinned actions

## Validation
- parse all workflow YAML files with Ruby Psych
- run git diff --check
