### PR TITLE
chore: run mypy on the primary Python target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
         run: ruff format --check .
 
       - name: Run type check
+        if: matrix.python-version == '3.13'
         run: mypy src/amigo_sdk/ --ignore-missing-imports
-        continue-on-error: true
 
       - name: Run tests with coverage
         run: pytest --cov=src --cov-report=xml --cov-report=term

--- a/src/amigo_sdk/errors.py
+++ b/src/amigo_sdk/errors.py
@@ -138,7 +138,7 @@ def get_error_class_for_status_code(status_code: int) -> type[AmigoError]:
         return AmigoError
 
 
-def raise_for_status(response, message: str = None) -> None:
+def raise_for_status(response, message: str | None = None) -> None:
     """
     Raise an appropriate AmigoError for non-2xx status codes.
 

--- a/src/amigo_sdk/generated/model.py
+++ b/src/amigo_sdk/generated/model.py
@@ -11948,7 +11948,11 @@ class GetConversationMessagesParametersQuery(BaseModel):
         title='Id',
     )
     message_type: list[MessageType] | None = Field(
-        ['agent-message', 'user-message', 'external-event'],
+        [
+            MessageType.agent_message,
+            MessageType.user_message,
+            MessageType.external_event,
+        ],
         description='The type of messages to retrieve.',
         title='Message Type',
     )

--- a/src/amigo_sdk/http_client.py
+++ b/src/amigo_sdk/http_client.py
@@ -164,6 +164,7 @@ class AmigoAsyncHttpClient:
                         "API-key exchange failed",
                     ) from e
 
+        assert self._token is not None
         return self._token.id_token
 
     async def request(self, method: str, path: str, **kwargs) -> httpx.Response:
@@ -312,6 +313,7 @@ class AmigoHttpClient:
                     self._token = sign_in_with_api_key(self._cfg)
                 except Exception as e:
                     raise AuthenticationError("API-key exchange failed") from e
+        assert self._token is not None
         return self._token.id_token
 
     def request(self, method: str, path: str, **kwargs) -> httpx.Response:
@@ -382,13 +384,13 @@ class AmigoHttpClient:
                 yield line_stripped
 
         if abort_event and abort_event.is_set():
-            return iter(())
+            return
         with self._client.stream(method, path, **kwargs) as resp:
             if resp.status_code == 401:
                 self._token = None
                 headers["Authorization"] = f"Bearer {self._ensure_token()}"
                 if abort_event and abort_event.is_set():
-                    return iter(())
+                    return
                 with self._client.stream(method, path, **kwargs) as retry_resp:
                     for ln in _yield_from_response(retry_resp):
                         yield ln

--- a/src/amigo_sdk/resources/agent.py
+++ b/src/amigo_sdk/resources/agent.py
@@ -8,6 +8,7 @@ from amigo_sdk.generated.model import (
     OrganizationCreateAgentVersionResponse,
     OrganizationGetAgentsResponse,
     OrganizationGetAgentVersionsResponse,
+    Version1,
 )
 from amigo_sdk.http_client import AmigoAsyncHttpClient, AmigoHttpClient
 
@@ -59,7 +60,7 @@ class AsyncAgentResource:
         """Create a new version for an agent."""
         params = None
         if version is not None:
-            query = CreateAgentVersionParametersQuery(version=version)
+            query = CreateAgentVersionParametersQuery(version=Version1(root=version))
             params = query.model_dump(mode="json", exclude_none=True)
         response = await self._http.request(
             "POST",
@@ -148,7 +149,7 @@ class AgentResource:
         """Create a new version for an agent."""
         params = None
         if version is not None:
-            query = CreateAgentVersionParametersQuery(version=version)
+            query = CreateAgentVersionParametersQuery(version=Version1(root=version))
             params = query.model_dump(mode="json", exclude_none=True)
         response = self._http.request(
             "POST",


### PR DESCRIPTION
Run mypy only on the 3.13 lane so Python CI stops surfacing non-blocking red annotations on the older matrix jobs while keeping a real typecheck gate in place.