### PR TITLE
ci: skip integration when secrets are unavailable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,21 +73,49 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
+      - name: Check integration environment
+        id: integration-env
+        env:
+          AMIGO_API_KEY: ${{ secrets.AMIGO_API_KEY }}
+          AMIGO_API_KEY_ID: ${{ secrets.AMIGO_API_KEY_ID }}
+          AMIGO_ORGANIZATION_ID: ${{ secrets.AMIGO_ORGANIZATION_ID }}
+          AMIGO_USER_ID: ${{ secrets.AMIGO_USER_ID }}
+          AMIGO_TEST_SERVICE_ID: ${{ secrets.AMIGO_TEST_SERVICE_ID }}
+        run: |
+          missing=()
+          for var in AMIGO_API_KEY AMIGO_API_KEY_ID AMIGO_ORGANIZATION_ID AMIGO_USER_ID AMIGO_TEST_SERVICE_ID; do
+            if [ -z "${!var}" ]; then
+              missing+=("$var")
+            fi
+          done
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping integration tests because required secrets are unavailable: ${missing[*]}"
+            exit 0
+          fi
+
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
+        if: steps.integration-env.outputs.ready == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python
+        if: steps.integration-env.outputs.ready == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: "pip"
 
       - name: Install dependencies
+        if: steps.integration-env.outputs.ready == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
       - name: Run integration tests
+        if: steps.integration-env.outputs.ready == 'true'
         env:
           AMIGO_API_KEY: ${{ secrets.AMIGO_API_KEY }}
           AMIGO_API_KEY_ID: ${{ secrets.AMIGO_API_KEY_ID }}


### PR DESCRIPTION
## Summary
- skip integration steps when required secrets are unavailable
- keep integration coverage on branches that actually have credentials
- stop dependabot PRs from showing red due to blank secrets

## Testing
- git diff --check
